### PR TITLE
Fixed source select bug

### DIFF
--- a/roku-card.js
+++ b/roku-card.js
@@ -230,10 +230,12 @@ class RokuCard extends LitElement {
   }
 
   launchApp(e) {
-    this.hass.callService("media_player", "select_source", {
-      entity_id: this._config.entity,
-      source: e.currentTarget.value
-    });
+    if (e.currentTarget.value != "") {
+      this.hass.callService("media_player", "select_source", {
+        entity_id: this._config.entity,
+        source: e.currentTarget.value
+      });
+    }
   }
 
   handleActionClick(e) {


### PR DESCRIPTION
The source selection box switches to an empty string briefly between selections, this was causing an error for the service call.